### PR TITLE
Store config/data in ~/.config/dmeternal on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ file and the game will start. If not, try right clicking and select "open
 with Python".
 
 The first time it's run, the game will create a "dmeternal" folder in your
-home directory and place a configuration file there. This is where all of your
-characters and saved games are stored, in case you want to delete them or
-make backups. The configuration file can be edited in any text editor.
+home directory (or in "~/.config" on Linux) and place a configuration file
+there. This is where all of your characters and saved games are stored, in
+case you want to delete them or make backups. The configuration file can be
+edited in any text editor.
 
 HOW TO PLAY
 ===========

--- a/util.py
+++ b/util.py
@@ -20,10 +20,14 @@
 #       
 # 
 import os
+import platform
 import ConfigParser
 
 
-USERDIR = os.path.expanduser( os.path.join( '~' , 'dmeternal' ) )
+if platform.system() == 'Linux':
+    USERDIR = os.path.expanduser( os.path.join( '~' , '.config' , 'dmeternal' ) )
+else:
+    USERDIR = os.path.expanduser( os.path.join( '~' , 'dmeternal' ) )
 if not os.path.exists( USERDIR ):
     os.mkdir( USERDIR )
 


### PR DESCRIPTION
~/.config is the default user-specific config location in the XDG Base Directory Specification.

It's better than dumping it smack-bang in the Linux user's home directory.
